### PR TITLE
restore requirements, without specifying versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# base requirements
+asgiref
+coverage
+Django
+sqlparse
+# additional requirements (add new ones under here)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Install using pip install -r requirements.txt
+
 # base requirements
 asgiref
 coverage


### PR DESCRIPTION
We can keep track of pip requirements here. To download these to your own python installation, use `pip install -r requirements.txt`.