### PR TITLE
Fix routing to allow direct links and refresh on Heroku

### DIFF
--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -14,10 +14,10 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, re_path, include
 from django.conf import settings
 from django.conf.urls.static import static
-
+from django.contrib.staticfiles.views import serve
 urlpatterns = [
     path('admin/', admin.site.urls),
 
@@ -25,3 +25,7 @@ urlpatterns = [
     path('api/', include('djoser.urls.authtoken')),
     path('api/', include('home.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# all other paths, solution from https://stackoverflow.com/questions/27065510/how-to-serve-static-files-with-django-that-has-hardcoded-relative-paths-on-herok/40525157#40525157
+urlpatterns += [re_path(r'^.*$', serve,
+                        kwargs={'path': '/vue/index.html'})]


### PR DESCRIPTION
Accomplished by routing `r'^.*$'` (any URL not in the above) to `/vue/index.html`, thus letting the Vue router handle that URL. This fixes refreshing and visiting direct URLs on Heroku.