### PR TITLE
Return 404 code when navigating to /404

### DIFF
--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -18,12 +18,15 @@ from django.urls import path, re_path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.staticfiles.views import serve
+from . import views
 urlpatterns = [
     path('admin/', admin.site.urls),
 
     path('api/', include('djoser.urls')),
     path('api/', include('djoser.urls.authtoken')),
     path('api/', include('home.urls')),
+    path('404', views.handleVue404, name='404'),
+
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # all other paths, solution from https://stackoverflow.com/questions/27065510/how-to-serve-static-files-with-django-that-has-hardcoded-relative-paths-on-herok/40525157#40525157

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -1,0 +1,12 @@
+from django.views.generic import TemplateView
+from django.shortcuts import render
+from django.views.static import serve
+from django.conf import settings
+
+
+def handleVue404(request):
+    '''Serve Vue.js app but return 404 status code, 404 page is handled by Vue.js'''
+    response = serve(request, '/vue/index.html',
+                     document_root=settings.STATIC_ROOT)
+    response.status_code = 404
+    return response


### PR DESCRIPTION
Django will still route to Vue and allow it to render the 404 page while Django returns a 404 response. 

Once CMPUT404W23T05/Social-Distribution-Front-End#58 is merged, all unknown URLs in Vue will be redirected to /404, though this still works as is.
