### PR TITLE
Nodemanagement

### DIFF
--- a/home/management/commands/api_key.py
+++ b/home/management/commands/api_key.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         anonymous_user, _ = User.objects.get_or_create(username='anonymous')
 
         # Create or update the token
-        token, _ = Token.objects.get_or_create(user=anonymous_user, key='itQmiFiX.HVJyCDX61EIHHjWRYm5naspa204iMrQA')
+        token, _ = Token.objects.get_or_create(user=anonymous_user, key='itQmiFiXHVJyCDX61EIHHjWRYm5naspa204iMrQA')
 
         # Print the token
         print(f'Token: {token.key}')

--- a/home/management/commands/api_key.py
+++ b/home/management/commands/api_key.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         anonymous_user, _ = User.objects.get_or_create(username='anonymous')
 
         # Create or update the token
-        token, _ = Token.objects.get_or_create(user=anonymous_user)
+        token, _ = Token.objects.get_or_create(user=anonymous_user, key='itQmiFiX.HVJyCDX61EIHHjWRYm5naspa204iMrQA')
 
         # Print the token
         print(f'Token: {token.key}')

--- a/home/management/commands/api_key.py
+++ b/home/management/commands/api_key.py
@@ -4,7 +4,7 @@ from rest_framework.authtoken.models import Token
 
 
 class Command(BaseCommand):
-    help = 'Creates a token for anonymous user'
+    help = 'Creates a generic api token for "anonymous" user'
 
     def handle(self, *args, **options):
         # Get or create the anonymous user

--- a/home/management/commands/delete_key.py
+++ b/home/management/commands/delete_key.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+
+class Command(BaseCommand):
+    help = 'Deletes the anonymous user and token'
+
+    def handle(self, *args, **options):
+        # Get the anonymous user
+        try:
+            anonymous_user = User.objects.get(username='anonymous')
+        except User.DoesNotExist:
+            self.stdout.write(self.style.WARNING('Anonymous user does not exist.'))
+            return
+
+        # Delete the token
+        try:
+            token = Token.objects.get(user=anonymous_user)
+            token.delete()
+        except Token.DoesNotExist:
+            self.stdout.write(self.style.WARNING('Token does not exist.'))
+
+        # Delete the user
+        anonymous_user.delete()
+
+        self.stdout.write(self.style.SUCCESS('Anonymous user and token deleted.'))

--- a/home/signals.py
+++ b/home/signals.py
@@ -13,7 +13,7 @@ import sys
 
 @receiver(post_save, sender=get_user_model())
 def create_author(sender, instance, created, **kwargs):
-    if created:
+    if created and instance.username not in ['admin', 'anonymous']:
         uid = str(uuid.uuid4())
         Author.objects.create(
                 # counts the number of comments on post any time a new instance of Comment is saved

--- a/home/signals.py
+++ b/home/signals.py
@@ -1,4 +1,6 @@
 
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.contrib.auth import get_user_model
@@ -13,7 +15,7 @@ import sys
 
 @receiver(post_save, sender=get_user_model())
 def create_author(sender, instance, created, **kwargs):
-    if created and instance.username not in ['admin', 'anonymous']:
+    if created and (instance.username not in ['admin', 'anonymous']) and (not instance.username.startswith('team')):
         uid = str(uuid.uuid4())
         Author.objects.create(
                 # counts the number of comments on post any time a new instance of Comment is saved
@@ -27,6 +29,16 @@ def create_author(sender, instance, created, **kwargs):
                 profile_image = "https://i.imgur.com/k7XVwpB.jpeg",
                 user = instance
                 )
+
+@receiver(post_save, sender=Remote)
+def create_user_and_token(sender, instance, created, **kwargs):
+    if created:
+        username = instance.name.lower()
+        user = User.objects.create_user(username=username)
+
+        token = Token.objects.create(user=user)
+
+
         
 @receiver(post_save, sender=Comment)
 def updated_post_count(sender, instance, created, **kwargs):


### PR DESCRIPTION
- [x] #38: can add nodes by adding their info in Remotes as admin
- [x] #39: can remove nodes by removing Remote instance from db as admin (this also automatically delete User and Token instances that correspond to that remote node
- [x] #41: nodes can be authenticated either with token auth or basic auth
- [x] #40: node connections can be limited using auth my admin (we can create a generic token using command api_key, disable generic token using cmd delete_key and can enable or disable node specific auth as admin, allowing control over node to node connections)
- [x] #42: we can disable node to node interfaces by removing a node from Remotes endpoint